### PR TITLE
Fix no terraform and no vagrant setup

### DIFF
--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -79,6 +79,7 @@ if (optionTerraform == "n") {
 
   assert new File(rootDir, "ansible/inventory/ec2.ini").delete()
   assert new File(rootDir, "ansible/inventory/ec2.py").delete()
+  assert new File(rootDir, "ansible/group_vars/ec2").deleteDir()
 }
 
 // remove Vagrant files if not required

--- a/src/main/resources/archetype-resources/ansible/group_vars/all/aem_dispatcher_flush.yml
+++ b/src/main/resources/archetype-resources/ansible/group_vars/all/aem_dispatcher_flush.yml
@@ -1,2 +1,5 @@
 # allow self signed certificates for dispatcher flush
 aem_dispatcher_flush_insecure: true
+
+# do not use a proxy for dispatcher flush
+aem_dispatcher_flush_noproxy: true

--- a/src/main/resources/archetype-resources/ansible/group_vars/all/conga_aem_dispatcher_smoke_test.yml
+++ b/src/main/resources/archetype-resources/ansible/group_vars/all/conga_aem_dispatcher_smoke_test.yml
@@ -1,2 +1,5 @@
 # allow self signed certificates for dispatcher flush
 conga_aemdst_curl_allow_insecure: true
+
+# do not use a proxy when executing the smoke test
+conga_aemdst_curl_noproxy: true

--- a/src/main/resources/archetype-resources/ansible/include-prepare-inventory.yml
+++ b/src/main/resources/archetype-resources/ansible/include-prepare-inventory.yml
@@ -43,9 +43,8 @@
         marker: "# {mark} conga_node to ip mapping - ANSIBLE MANAGED BLOCK"
 
 #end
-- name: "generate inventory (local)"
-  hosts: "&local:&tag_Project_${configurationManagementName}:&tag_Env_{{ conga_environment }}"
-  gather_facts: no
+- name: "generate inventory (not ec2)"
+  hosts: "&not_ec2:&tag_Project_${configurationManagementName}:&tag_Env_{{ conga_environment }}"
   become: yes
   tags:
     - prepare-inventory
@@ -54,8 +53,23 @@
       set_fact:
         conga_node_ip_mapping_private: []
 
-    - name: update hosts file
+    - name: "Get ip adresses and defined 'conga_nodes' of all hosts in play."
+      set_fact:
+        conga_node_ip_mapping_private: "{{ conga_node_ip_mapping_private + [hostvars[item]['ansible_default_ipv4']['address']+' '+hostvars[item].conga_nodes | join(' ')] }}"
+      with_items: "{{ hostvars }}"
+      when:
+        - hostvars[item].conga_nodes is defined
+        - hostvars[item].ansible_default_ipv4 is defined
+        - item != inventory_hostname
+
+    - name: "Convert conga_node ip mapping list to a string."
+      set_fact:
+        conga_node_ip_mapping_private_str: "{{ conga_node_ip_mapping_private | join ('\n') }}"
+
+    - name: "Update hosts file."
       blockinfile:
         path: /etc/hosts
-        block: "127.0.0.1 {{ conga_nodes | join(' ') }}"
+        block: |
+          127.0.0.1 {{ conga_nodes | join(' ') }}
+          {{ conga_node_ip_mapping_private_str }}
         marker: "# {mark} conga_node to ip mapping - ANSIBLE MANAGED BLOCK"

--- a/src/main/resources/archetype-resources/ansible/include-setup-aem-cms.yml
+++ b/src/main/resources/archetype-resources/ansible/include-setup-aem-cms.yml
@@ -20,7 +20,12 @@
         aem_cms_home: "{{ conga_config.quickstart.rootPath }}"
 
   roles:
-    - { role: geerlingguy.swap, swap_file_size_mb: '1024', tags: ['swap'] }
+    - {
+        role: geerlingguy.swap,
+        swap_file_size_mb: '1024',
+        tags: ['swap'],
+        when: ansible_swaptotal_mb == 0 # only create swap when no swap exists
+      }
     - {
         role: wcm_io_devops.aem_cms,
         tags: ['dev.aem_cms']

--- a/src/main/resources/archetype-resources/ansible/include-setup-aem-cms.yml
+++ b/src/main/resources/archetype-resources/ansible/include-setup-aem-cms.yml
@@ -20,7 +20,7 @@
         aem_cms_home: "{{ conga_config.quickstart.rootPath }}"
 
   roles:
-    - { role: geerlingguy.swap, swap_file_size_mb: '1024' }
+    - { role: geerlingguy.swap, swap_file_size_mb: '1024', tags: ['swap'] }
     - {
         role: wcm_io_devops.aem_cms,
         tags: ['dev.aem_cms']

--- a/src/main/resources/archetype-resources/ansible/inventory/dev
+++ b/src/main/resources/archetype-resources/ansible/inventory/dev
@@ -1,5 +1,5 @@
 [controlhost]
-localhost
+localhost ansible_connection=local
 
 [tag_conga_variants_aem-author]
 192.168.0.1
@@ -14,4 +14,10 @@ localhost
 192.168.0.1
 
 [tag_Project_${configurationManagementName}]
+192.168.0.1
+
+[tag_Env_dev]
+192.168.0.1 conga_nodes='["author-dev.website1.com", "dev.website1.com"]' conga_variants='["aem-author","aem-publish"]' conga_variant_node_mapping='["aem-author=author-dev.website1.com","aem-publish=dev.website1.com"]'
+
+[not_ec2]
 192.168.0.1

--- a/src/main/resources/archetype-resources/ansible/inventory/local
+++ b/src/main/resources/archetype-resources/ansible/inventory/local
@@ -21,3 +21,6 @@ localhost
 
 [not_ec2]
 localhost
+
+[local]
+localhost

--- a/src/main/resources/archetype-resources/ansible/inventory/local
+++ b/src/main/resources/archetype-resources/ansible/inventory/local
@@ -1,8 +1,5 @@
-[local]
-localhost
-
 [controlhost]
-localhost
+localhost ansible_connection=local
 
 [tag_conga_variants_aem-author]
 localhost
@@ -20,4 +17,7 @@ localhost
 localhost
 
 [tag_Env_local]
+localhost
+
+[not_ec2]
 localhost

--- a/src/main/resources/archetype-resources/ansible/inventory/prod
+++ b/src/main/resources/archetype-resources/ansible/inventory/prod
@@ -1,24 +1,34 @@
 [controlhost]
-localhost
+localhost ansible_connection=local
 
 [tag_conga_variants_aem-author]
-192.168.0.1
+192.168.0.2
 
 [tag_conga_variants_aem-publish]
-192.168.0.2
 192.168.0.3
+192.168.0.4
 
 [tag_conga_roles_aem-cms]
-192.168.0.1
 192.168.0.2
 192.168.0.3
+192.168.0.4
 
 [tag_conga_roles_aem-dispatcher]
-192.168.0.1
 192.168.0.2
 192.168.0.3
+192.168.0.4
 
 [tag_Project_${configurationManagementName}]
-192.168.0.1
 192.168.0.2
 192.168.0.3
+192.168.0.4
+
+[tag_Env_prod]
+192.168.0.2 conga_nodes='["author.website1.com"]' conga_variants='["aem-author"]'
+192.168.0.3 conga_nodes='["publish1.website1.com"]' conga_variants='["aem-publish"]'
+192.168.0.4 conga_nodes='["publish2.website1.com"]' conga_variants='["aem-publish"]'
+
+[not_ec2]
+192.168.0.2
+192.168.0.3
+192.168.0.4

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -57,7 +57,7 @@
 - src: https://github.com/wcm-io-devops/ansible-conga-aem-dispatcher-smoke-test.git
   name: wcm_io_devops.conga_aem_dispatcher_smoke_test
   scm: git
-  version: c7203cf824915f63aaf008379c4c27d366b48558
+  version: bf5bf9b3dc70114a7215f1466c77cc727fc86d37
 - src: https://github.com/wcm-io-devops/ansible-conga-aem-packages.git
   name: wcm_io_devops.conga_aem_packages
   scm: git

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -85,7 +85,7 @@
 - src: https://github.com/wcm-io-devops/ansible-conga-host-facts.git
   name: wcm_io_devops.conga_host_facts
   scm: git
-  version: 074727024ce7fb6da18b8bf313781accc43614d7
+  version: 6c92e58cd65a00de049f7043b45298e8f70c676c
 - src: https://github.com/wcm-io-devops/ansible-role-apache.git
   name: wcm_io_devops.apache
   scm: git


### PR DESCRIPTION
This PR already has https://github.com/wcm-io/wcm-io-maven-archetype-aem-confmgmt/pull/6 included.

Major changes:
* only create swap file when target system has not already a swap (otherwise this may collide with LXC virtualized environments)
* Do not use proxy during dispatcher flush and dispatcher smoke test
* Add host file creation for dev and prod when not running in ec2 (added `not_ec2` group for this purpose)
* Update dev and prod environment with required conga variables
* Update roles `wcm_io_devops.conga_aem_dispatcher_smoke_test` and `wcm_io_devops.conga_host_facts`
* Changed localhost connection to `localhost ansible_connection=local` to avoid issues with not existing `ANSIBLE_VAULT_PASSWORD_FILE` when running wcm_io_devops.conga_maven