### PR TITLE
Fix ownership of projects dir in vagrant vm.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="fix" dev="trichter">
         Remove usage of vagrant-vbguest plugin since it is not needed.
       </action>
+      <action type="fix" dev="trichter">
+        Fix ownership on projects dir in vagrant vm.
+      </action>
     </release>
 
     <release version="1.0.2" date="2018-09-08">

--- a/src/main/resources/archetype-resources/vagrant/provision-base.sh
+++ b/src/main/resources/archetype-resources/vagrant/provision-base.sh
@@ -2,7 +2,7 @@
 set -e
 
 HOME_DIR="/home/vagrant"
-PROJECT_DIR="/home/vagrant/projects/${configurationManagementName}"
+PROJECTS_DIR="/home/vagrant/projects"
 ANSIBLE_DIR="$HOME/.ansible"
 ANSIBLE_VAULT_PASS_DEST="$ANSIBLE_DIR/.vault_pass"
 ANSIBLE_VAULT_PASS_SRC="/vagrant/shared/.vault_pass"
@@ -55,6 +55,9 @@ mkdir -p $AWS_CONFIG_DIR
 chmod 0700 $AWS_CONFIG_DIR
 cp "$AWS_CREDENTIALS_SRC" "$AWS_CREDENTIALS_DEST"
 chmod -R 0600 $AWS_CONFIG_DIR/*
+
+echo "Change ownership on projects dir"
+sudo chown -R vagrant:vagrant "$PROJECTS_DIR"
 
 # install git
 echo "Install GIT for Ansible Galaxy"


### PR DESCRIPTION
In the Vagrant vm the folder `/home/vagrant/projects` is owned by root:root.
This PR changes the ownership to `vagrant:vagrant`.