### PR TITLE
Add host file creation on controlhost for non ec2 environments

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.0.4" date="not released">
+      <action type="add" dev="trichter">
+        Hosts file creation on controlhost for non ec2 environments.
+      </action>
       <action type="fix" dev="trichter">
         Remove usage of vagrant-vbguest plugin since it is not needed.
       </action>

--- a/src/main/resources/archetype-resources/ansible/include-prepare-inventory.yml
+++ b/src/main/resources/archetype-resources/ansible/include-prepare-inventory.yml
@@ -73,3 +73,10 @@
           127.0.0.1 {{ conga_nodes | join(' ') }}
           {{ conga_node_ip_mapping_private_str }}
         marker: "# {mark} conga_node to ip mapping - ANSIBLE MANAGED BLOCK"
+
+    - name: "Write hostfile info to controlhost."
+      copy:
+        content: |
+          127.0.0.1 {{ conga_nodes | join(' ') }}
+          {{ conga_node_ip_mapping_private_str }}
+        dest: "{{ playbook_dir }}/files/tmp/hosts_{{ conga_environment }}"


### PR DESCRIPTION
At adaptTo() 2018 i noticed that we are not generating a hosts file on the controlhost for non ec2 environments. This PR adds this functionality.