### PR TITLE
Update wcm_io_devops.conga_ansible_controlhost requirement to 1.2.0

### DIFF
--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -43,7 +43,7 @@
 - name: wcm_io_devops.conga_aem_smoke_test
   version: 1.0.0
 - name: wcm_io_devops.conga_ansible_controlhost
-  version: 1.0.0
+  version: 1.2.0
 - name: wcm_io_devops.conga_maven
   version: 1.0.0
 - name: wcm_io_devops.conga_facts


### PR DESCRIPTION
I just released a new version of the wcm_io_devops.conga_ansible_controlhost role.
This release contains a bugfix for setting the default editor.

Please review and merge when you have time, this is not urgent.