### PR TITLE
Update io.wcm.maven.aem-global-parent to 1.2.28

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="trichter">
         Update Ansible role dependencies.
       </action>
+      <action type="update" dev="trichter">
+        Update io.wcm.maven.aem-global-parent to 1.2.28.
+      </action>
     </release>
 
     <release version="1.0.4" date="2018-09-14">

--- a/src/main/resources/archetype-resources/configuration/pom.xml
+++ b/src/main/resources/archetype-resources/configuration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.wcm.maven</groupId>
     <artifactId>io.wcm.maven.aem-global-parent</artifactId>
-    <version>1.2.26</version>
+    <version>1.2.28</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Updated parent because building the configuration management of the archetype currently fails with

```
Newer CONGA maven plugin or plugin version required: io.wcm.devops.conga.plugins:io.wcm.devops.conga.plugins.aem:1.8.12
``` 