### PR TITLE
Fix vagrant hostname when configurationManagementName contains dots

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="trichter">
         Update io.wcm.maven.aem-global-parent to 1.2.28.
       </action>
+      <action type="fix" dev="trichter">
+        Fix vagrant hostname when configurationManagementName contains dots.
+      </action>
     </release>
 
     <release version="1.0.4" date="2018-09-14">

--- a/src/main/resources/archetype-resources/vagrant/Vagrantfile
+++ b/src/main/resources/archetype-resources/vagrant/Vagrantfile
@@ -10,7 +10,7 @@ CPUEXECUTIONCAP = 80
 
 RSYNC_EXCLUDES = [".git/",".idea/","target/"]
 
-HOSTNAME = "${configurationManagementName}-controlhost"
+HOSTNAME = "${configurationManagementName.replace('.','_')}-controlhost"
 
 # ssh port
 SSH_PORT = 22022


### PR DESCRIPTION
When the `configurationManagementName` contains dots like `io.wcm.cfg-mgmt` the displayed hostname in the shell will be `io`.

With this change the hostname will be `io_wcm_cfg-mgmt`.