### PR TITLE
Use hyphens instead of underscore in vagrant hostname

### DIFF
--- a/src/main/resources/archetype-resources/vagrant/Vagrantfile
+++ b/src/main/resources/archetype-resources/vagrant/Vagrantfile
@@ -10,7 +10,7 @@ CPUEXECUTIONCAP = 80
 
 RSYNC_EXCLUDES = [".git/",".idea/","target/"]
 
-HOSTNAME = "${configurationManagementName.replace('.','_')}-controlhost"
+HOSTNAME = "${configurationManagementName.replace('.','-')}-controlhost"
 
 # ssh port
 SSH_PORT = 22022


### PR DESCRIPTION
This fixes https://github.com/wcm-io/wcm-io-maven-archetype-aem-confmgmt/pull/18.

Sadly underscores are forbidden. We have to use hyphens instead.
