### PR TITLE
Update vm during provisioning

### DIFF
--- a/src/main/resources/archetype-resources/vagrant/provision-base.sh
+++ b/src/main/resources/archetype-resources/vagrant/provision-base.sh
@@ -62,3 +62,6 @@ sudo chown -R vagrant:vagrant "$PROJECTS_DIR"
 # install git
 echo "Install GIT for Ansible Galaxy"
 sudo yum install git -y -q
+# update distribution to avoid package conflicts during XMP dependency installation
+echo "OS Update"
+sudo yum update -y


### PR DESCRIPTION
We have to update the VM during provisioning. Otherwise this may lead to yum conflicts when installing the i386 XMP dependencies.