### PR TITLE
Update Ansible roles

### DIFF
--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -18,7 +18,7 @@
 - name: wcm_io_devops.aem_service
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_cms
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_bundle_files
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -28,7 +28,7 @@
 - name: wcm_io_devops.conga_aem_dispatcher_smoke_test
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_packages
-  version: 1.1.0
+  version: 1.2.0
 - name: wcm_io_devops.conga_aem_smoke_test
   version: 1.0.1
 - name: wcm_io_devops.conga_ansible_controlhost

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -39,7 +39,7 @@
 - name: wcm_io_devops.conga_aem_dispatcher_smoke_test
   version: 1.0.0
 - name: wcm_io_devops.conga_aem_packages
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_aem_smoke_test
   version: 1.0.0
 - name: wcm_io_devops.conga_ansible_controlhost

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -20,7 +20,7 @@
 - name: wcm_io_devops.conga_aem_cms
   version: 1.0.0
 - name: wcm_io_devops.conga_bundle_files
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher
   version: 1.0.0
 - name: wcm_io_devops.conga_aem_dispatcher_flush

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -1,19 +1,8 @@
 #
 # ansible galaxy requirements
 #
-  # alternative to williamyeh.oracle-java
-- src: srsp.oracle-java
-  version: 2.19.2
 - src: geerlingguy.swap
   version: 1.0.0
-- src: gantsign.maven
-  version: 4.0.0
-- src: geerlingguy.repo-epel
-  version: 1.2.3
-#if( $optionTerraform=="y" )
-- src: andrewrothstein.terraform
-  version: v2.2.10
-#end
 
 #
 # wcm-io-devops requirements

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -12,7 +12,7 @@
 - name: wcm_io_devops.aem_dispatcher
   version: 1.0.0
 - name: wcm_io_devops.aem_dispatcher_flush
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.aem_security
   version: 1.1.0
 - name: wcm_io_devops.aem_service

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -14,7 +14,7 @@
 - name: wcm_io_devops.aem_dispatcher_flush
   version: 1.0.0
 - name: wcm_io_devops.aem_security
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.aem_service
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_cms

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -8,7 +8,7 @@
 # wcm-io-devops requirements
 #
 - name: wcm_io_devops.aem_cms
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.aem_dispatcher
   version: 1.0.0
 - name: wcm_io_devops.aem_dispatcher_flush

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -42,4 +42,4 @@
 - name: wcm_io_devops.conga_host_facts
   version: 1.0.0
 - name: wcm_io_devops.apache
-  version: 3.0.0-1
+  version: 3.0.3-1

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -10,7 +10,7 @@
 - name: wcm_io_devops.aem_cms
   version: 1.1.0
 - name: wcm_io_devops.aem_dispatcher
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.aem_dispatcher_flush
   version: 1.1.0
 - name: wcm_io_devops.aem_security
@@ -40,6 +40,6 @@
 - name: wcm_io_devops.conga_files
   version: 1.0.0
 - name: wcm_io_devops.conga_host_facts
-  version: 1.0.0
+  version: 1.0.1
 - name: wcm_io_devops.apache
   version: 3.0.3-1

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -24,7 +24,7 @@
 - name: wcm_io_devops.conga_aem_dispatcher
   version: 1.0.0
 - name: wcm_io_devops.conga_aem_dispatcher_flush
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher_smoke_test
   version: 1.0.0
 - name: wcm_io_devops.conga_aem_packages

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -16,7 +16,7 @@
 - name: wcm_io_devops.aem_security
   version: 1.0.0
 - name: wcm_io_devops.aem_service
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_aem_cms
   version: 1.0.0
 - name: wcm_io_devops.conga_bundle_files

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -3,7 +3,7 @@
 #
   # alternative to williamyeh.oracle-java
 - src: srsp.oracle-java
-  version: 2.19.1
+  version: 2.19.2
 - src: geerlingguy.swap
   version: 1.0.0
 - src: gantsign.maven

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -26,7 +26,7 @@
 - name: wcm_io_devops.conga_aem_dispatcher_flush
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher_smoke_test
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_aem_packages
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_smoke_test

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -32,7 +32,7 @@
 - name: wcm_io_devops.conga_aem_smoke_test
   version: 1.0.0
 - name: wcm_io_devops.conga_ansible_controlhost
-  version: 1.2.0
+  version: 2.0.0
 - name: wcm_io_devops.conga_maven
   version: 1.0.0
 - name: wcm_io_devops.conga_facts

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -22,7 +22,7 @@
 - name: wcm_io_devops.conga_bundle_files
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher
-  version: 1.0.0
+  version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher_flush
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_dispatcher_smoke_test

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -30,7 +30,7 @@
 - name: wcm_io_devops.conga_aem_packages
   version: 1.1.0
 - name: wcm_io_devops.conga_aem_smoke_test
-  version: 1.0.0
+  version: 1.0.1
 - name: wcm_io_devops.conga_ansible_controlhost
   version: 2.0.0
 - name: wcm_io_devops.conga_maven


### PR DESCRIPTION
This PR updates the wcm-io-devops Ansible Roles to the latest releases.
It also removed duplicate defined dependencies since 
* srsp.oracle-java
* gantsign.maven
* geerlingguy.repo-epel
* andrewrothstein.terraform

are defined in wcm_io_devops.conga_ansible_controlhost