### PR TITLE
Fix JDK Installation

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.0.8" date="not released">
+      <action type="update" dev="trichter">
+        Update Ansible role dependencies.
+      </action>
+    </release>
+
     <release version="1.0.6" date="2018-12-05">
       <action type="update" dev="trichter">
         Update Ansible role dependencies.

--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="trichter">
         Update Ansible role dependencies.
       </action>
+      <action type="update" dev="trichter">
+        Update default JDK to 8u191.
+      </action>
     </release>
 
     <release version="1.0.6" date="2018-12-05">

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -100,7 +100,7 @@
     </requiredProperty>
     <!-- Java minor version -->
     <requiredProperty key="javaMinorVersion">
-      <defaultValue>181</defaultValue>
+      <defaultValue>191</defaultValue>
       <validationRegex>^\d+$</validationRegex>
     </requiredProperty>
     <!-- Download base URL for Java SDK binaries -->

--- a/src/main/resources/archetype-resources/ansible/requirements.yml
+++ b/src/main/resources/archetype-resources/ansible/requirements.yml
@@ -8,7 +8,7 @@
 # wcm-io-devops requirements
 #
 - name: wcm_io_devops.aem_cms
-  version: 1.1.0
+  version: 1.1.1
 - name: wcm_io_devops.aem_dispatcher
   version: 1.1.0
 - name: wcm_io_devops.aem_dispatcher_flush
@@ -32,7 +32,7 @@
 - name: wcm_io_devops.conga_aem_smoke_test
   version: 1.0.1
 - name: wcm_io_devops.conga_ansible_controlhost
-  version: 2.0.2
+  version: 2.0.3
 - name: wcm_io_devops.conga_maven
   version: 1.0.0
 - name: wcm_io_devops.conga_facts

--- a/src/test/resources/projects/alpha-all/archetype.properties
+++ b/src/test/resources/projects/alpha-all/archetype.properties
@@ -20,7 +20,7 @@ awsMachineSize=lage
 
 # Java SDK
 javaMajorVersion=8
-javaMinorVersion=181
+javaMinorVersion=191
 javaDownloadBaseUrl=http://download.oracle.com/otn-pub/java
 
 # file references

--- a/src/test/resources/projects/beta-no-vagrant/archetype.properties
+++ b/src/test/resources/projects/beta-no-vagrant/archetype.properties
@@ -20,7 +20,7 @@ awsMachineSize=medium
 
 # Java SDK
 javaMajorVersion=8
-javaMinorVersion=181
+javaMinorVersion=191
 javaDownloadBaseUrl=http://download.oracle.com/otn-pub/java
 
 # file references

--- a/src/test/resources/projects/delta-no-terraform-no-vagrant-no-ansible/archetype.properties
+++ b/src/test/resources/projects/delta-no-terraform-no-vagrant-no-ansible/archetype.properties
@@ -20,7 +20,7 @@ awsMachineSize=small
 
 # Java SDK
 javaMajorVersion=8
-javaMinorVersion=181
+javaMinorVersion=191
 javaDownloadBaseUrl=http://download.oracle.com/otn-pub/java
 
 # file references

--- a/src/test/resources/projects/gamma-no-terraform-no-vagrant/archetype.properties
+++ b/src/test/resources/projects/gamma-no-terraform-no-vagrant/archetype.properties
@@ -20,7 +20,7 @@ awsMachineSize=medium
 
 # Java SDK
 javaMajorVersion=8
-javaMinorVersion=181
+javaMinorVersion=191
 javaDownloadBaseUrl=http://download.oracle.com/otn-pub/java
 
 # file references


### PR DESCRIPTION
I noticed problems when running the archetype without customized JDK version.

I released new versions of
* https://galaxy.ansible.com/wcm_io_devops/aem_cms
* https://galaxy.ansible.com/wcm_io_devops/conga_ansible_controlhost

which do not specify a specific version of the used java role.
With this change we will always use the latest release which supports also the latest JDK version.

I also increased the default JDK version to 8u191.

**Additional changes that should be implemented**

From my perspective we should make the properties
* `javaMajorVersion`
* `javaMinorVersion`
* `javaDownloadBaseUrl`

completely optional, so we are able to use the role defaults of `srsp.oracle-java` and we don't have to update the archetype on every JDK release.

I tried it by myself but i am not the Maven Archetype specialist.

We should only render the lines: https://github.com/wcm-io/wcm-io-maven-archetype-aem-confmgmt/blob/develop/src/main/resources/archetype-resources/ansible/group_vars/all/oracle-java.yml#L3-L5 when the properties `javaMajorVersion` and `javaMinorVersion` are set.

When `javaDownloadBaseUrl` is set we should render https://github.com/wcm-io/wcm-io-maven-archetype-aem-confmgmt/blob/develop/src/main/resources/archetype-resources/ansible/group_vars/all/oracle-java.yml#L7-L8.