### PR TITLE
Add vagrant-vbguest Vagrant plugin 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.0.8" date="not released">
+      <action type="fix" dev="trichter">
+        Add vagrant-vbguest Vagrant plugin to fix missing guest additions after kernel upgrade and reboot.
+      </action>
+    </release>
+
     <release version="1.0.6" date="2018-12-05">
       <action type="update" dev="trichter">
         Update Ansible role dependencies.

--- a/src/main/resources/archetype-resources/vagrant/README.md
+++ b/src/main/resources/archetype-resources/vagrant/README.md
@@ -12,11 +12,17 @@ This [Vagrant][vagrant] environment sets up an Ansible Control Host that can be 
 ${symbol_pound}${symbol_pound} Requirements
 
 * Vagrant 2.1.2
+  * [vagrant-vbguest plugin](vagrant-vbguest)
 * Oracle VM VirtualBox 5.2
 * SSH Agent or Putty Pageant
 
 
 ${symbol_pound}${symbol_pound} Setup Vagrant environment
+
+${symbol_pound}${symbol_pound}${symbol_pound} Install required Vagrant
+plugins
+
+    vagrant plugin install vagrant-vbguest
 
 ${symbol_pound}${symbol_pound}${symbol_pound} Provide vault password
 
@@ -71,3 +77,4 @@ If you want to constanly push changes to the VM run
 
 
 [vagrant]: https://www.vagrantup.com/
+[vagrant-vbguest]: https://github.com/dotless-de/vagrant-vbguest

--- a/src/main/resources/archetype-resources/vagrant/Vagrantfile
+++ b/src/main/resources/archetype-resources/vagrant/Vagrantfile
@@ -33,6 +33,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 4502, host: 4502, id: 'aem-author'
   config.vm.network :forwarded_port, guest: 4503, host: 4503, id: 'aem-publish'
 
+  # force auto update of VirtualBox guest additions
+  config.vbguest.auto_update = true
+
   config.vm.provider "virtualbox" do |vb|
     # set cpu exectuion gab
     vb.customize ["modifyvm", :id, "--cpuexecutioncap", "#{CPUEXECUTIONCAP}"]


### PR DESCRIPTION
For the shared Folders we require the VirtualBox Guest Addtions to be installed so we have to add the 
vagrant-vbguest plugin to the requirements.

Even when they are already installed in the used VM we have to perform a installation check on each start in case of Kernel Updates.