### PR TITLE
Raise Ansible version to 2.7.13

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.2.0" date="2019-10-08">
+      <action type="update" dev="nbellack">
+        Update Ansible version to 2.7.13.
+      </action>
+    </release>
+
     <release version="1.1.0" date="2019-10-02">
       <action type="add" dev="sseifert">
         Make AEM major version configurable. Defaults to AEM 6.5.

--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.2.0" date="2019-10-08">
+    <release version="1.2.0" date="not released">
       <action type="update" dev="nbellack">
         Update Ansible version to 2.7.13.
       </action>

--- a/src/main/resources/archetype-resources/vagrant/Vagrantfile
+++ b/src/main/resources/archetype-resources/vagrant/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "ansible_local" do |ansible|
     ansible.provisioning_path = "/home/vagrant/projects/${configurationManagementName}/ansible"
     ansible.install_mode = "pip"
-    ansible.version = "2.4.6.0"
+    ansible.version = "2.7.13"
     ansible.compatibility_mode = "2.0"
     # galaxy settings
     ansible.galaxy_role_file = "requirements.yml"


### PR DESCRIPTION
Since previous version 2.4.6.0 reached end of life, we should use a newer version that is still supported.