### PR TITLE
Grape issue workaround

### DIFF
--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,3 +1,4 @@
+@GrabResolver(name='central', root='https://repo.maven.apache.org/maven2/')
 // renovate: depName=io.wcm.devops.conga.plugins:conga-aem-crypto-cli
 @Grab(group="io.wcm.devops.conga.plugins", module="conga-aem-crypto-cli", version="2.20.2")
 import groovy.io.FileType


### PR DESCRIPTION
to work around issue happening only in github actions:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:3.4.0:integration-test (default-integration-test) on project io.wcm.maven.archetypes.aem-confmgmt: Execution default-integration-test of goal org.apache.maven.plugins:maven-archetype-plugin:3.4.0:integration-test failed: startup failed:
Error: [ERROR] General error during conversion: Error grabbing Grapes -- [download failed: commons-io#commons-io;2.18.0!commons-io.jar]
Error:  
Error:  java.lang.RuntimeException: Error grabbing Grapes -- [download failed: commons-io#commons-io;2.18.0!commons-io.jar]
Error:  	at groovy.grape.GrapeIvy.getDependencies(GrapeIvy.groovy:479)
Error:  	at groovy.grape.GrapeIvy.resolve(GrapeIvy.groovy:640)
Error:  	at groovy.grape.GrapeIvy.resolve(GrapeIvy.groovy:616)
Error:  	at groovy.grape.GrapeIvy.grab(GrapeIvy.groovy:280)
Error:  	at groovy.grape.Grape$1.run(Grape.java:172)
Error:  	at groovy.grape.Grape$1.run(Grape.java:158)
...
```

it's not really clear to my why this `@GrabResolver` seems to solve the problem - it was not required in previous builds of this projects, it's not required for https://github.com/wcm-io/io.wcm.maven.archetypes.aem - which also has a @Grab in it's groovy script (but for a different dependency)